### PR TITLE
JSLoader: fix `asmexposedfunction` not working properly

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSLoader.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSLoader.kt
@@ -166,7 +166,7 @@ object JSLoader : ILoader {
     override fun asmInvokeLookup(module: Module, functionURI: URI): MethodHandle {
         return wrapInContext {
             try {
-                val returned = require.loadCTModule(module.name, functionURI)
+                val returned = require.loadCTModule("${module.name}-asmexp$$", functionURI)
                 val func = ScriptableObject.getProperty(returned, "default") as Callable
 
                 // When a call to this function ID is made, we always want to point it


### PR DESCRIPTION
This fixes an issue that was introduced in ct 2.2.1 which makes the `asmexposedfunction`s never be found
uses the same fix as `asmPass` for module name